### PR TITLE
Copy Title, Set Current Focused tab Url as Link buttons 

### DIFF
--- a/src/css/pop_series.css
+++ b/src/css/pop_series.css
@@ -32,6 +32,14 @@
     border-color: var(--border-color-new);
 }
 
+[new_releases=true] .copyTitleButton {
+    border-color: var(--border-color-new);
+}
+
+[new_releases=true] .tabURLAsLinkButton {
+    border-color: var(--border-color-new);
+}
+
 [new_releases=true] .seriesTitleBlock {
     border-right-color: var(--border-color-new);
 }
@@ -72,6 +80,14 @@
 }
 
 [new_releases=false] .editLinkButton {
+    border-color: var(--border-color);
+}
+
+[new_releases=false] .copyTitleButton {
+    border-color: var(--border-color);
+}
+
+[new_releases=false] .tabURLAsLinkButton {
     border-color: var(--border-color);
 }
 

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -238,6 +238,105 @@ button {
     background-color: var(--color-brighten-more);
 }
 
+.copyTitleWrap {
+    position: relative;
+    height: 0px;
+}
+
+.copyTitleButton {
+    position: absolute;
+    border: 1px dotted;
+    border-color: var(--border-color);
+    border-top-left-radius: var(--block-border-radius);
+    border-top-right-radius: var(--block-border-radius);
+    border-bottom-left-radius: var(--block-border-radius);
+    border-bottom-right-radius: var(--block-border-radius);
+    right: 148px;
+    bottom: 33px;
+    width: 16px;
+    height: 16px;
+    overflow: hidden;
+    opacity: .95;
+}
+    .copyTitleButton:hover {
+        background-color: var(--color-brighten);
+        cursor:pointer;
+        opacity: 1;
+    }
+    .copyTitleButton:active {
+        transform: translateY(1px);
+    }
+
+.copyTitleIcon {
+    position:relative;
+    right:-1px;
+    bottom:7px;
+    font-size: 20px;
+    font-weight: bolder;
+    opacity:.4;
+    background-color:initial;
+}
+
+.tabURLAsLinkWrap {
+    position: relative;
+    height: 0px;
+}
+
+.tabURLAsLinkButton {
+    position: absolute;
+    border: 1px dotted;
+    border-color: var(--border-color);
+    border-top-left-radius: var(--block-border-radius);
+    border-top-right-radius: var(--block-border-radius);
+    border-bottom-left-radius: var(--block-border-radius);
+    border-bottom-right-radius: var(--block-border-radius);
+    right: 128px;
+    bottom: 33px;
+    width: 16px;
+    height: 16px;
+    overflow: hidden;
+    opacity: .95;
+}
+    .tabURLAsLinkButton:hover {
+        background-color: var(--color-brighten);
+        cursor:pointer;
+        opacity: 1;
+    }
+    .tabURLAsLinkButton:active {
+        transform: translateY(1px);
+    }
+
+.tabURLAsLinkIcon {
+    position:relative;
+    right:-1px;
+    bottom:9px;
+    font-size: 20px;
+    font-weight: bolder;
+    opacity:.4;
+    background-color:initial;
+}
+
+.titleSetLinkCurrentPage {
+    position: absolute;
+    border: 1px dotted;
+    border-color: var(--border-color);
+    border-top-left-radius: var(--block-border-radius);
+    border-top-right-radius: var(--block-border-radius);
+    border-bottom-left-radius: var(--block-border-radius);
+    border-bottom-right-radius: var(--block-border-radius);
+    right: 130px;
+    top: 20px;
+    width: 16px;
+    height: 16px;
+    overflow: hidden;
+    opacity: .95;
+}
+.titleSetLinkCurrentPage:hover {
+    background-color: var(--color-brighten);
+    cursor:pointer;
+    opacity: 1;
+}
+
 .seriesReleaseBlock {
     overflow: hidden;
     height: 50px;

--- a/src/js/animation.js
+++ b/src/js/animation.js
@@ -101,7 +101,7 @@ function animateToggleManageMode(toggle, callback) {
 
 			animateToggleManageField(toggle, callback);
 			animateToggleUpToDateSelect(toggle, onscreen_rows);
-			animateToggleEditLink(toggle, onscreen_rows);
+			animateToggleManageButtons(toggle, onscreen_rows);
 		});
 	} else {
 		callback(toggle);
@@ -224,24 +224,33 @@ function animateElementColorChange(element, color_old, color_new, callback) {
 }
 
 /**
- * plays animation for series link button moving from/to its title block position
+ * plays animation for series manage buttons moving from/to its title block position
  * @param {boolean} toggle
  * @param {Element[]} onscreen_rows
  */
-function animateToggleEditLink(toggle, onscreen_rows) {
+function animateToggleManageButtons(toggle, onscreen_rows) {
 	var d_y = 75;
 	var y0 = toggle ? 0 : d_y;
 	var y1 = toggle ? d_y : 0;
 	var time_anim = 200;
 	fastdom.mutate(function () {
 		for (var i = 0; i < onscreen_rows.length; i++) {
-			var edit_link_wrap = getSeriesRowsEditLinkWrap(onscreen_rows[i]);
-			edit_link_wrap.style.display = "";
-			var link_anim = edit_link_wrap.animate([
+			var transform = [
 				{ transform: `translateY(${-y1}px)` },
 				{ offset: 0.8, transform: `translateY(${-y0}px)` },
 				{ transform: `translateY(${-y0}px)` }
-			], { duration: time_anim, easing: 'linear' });
+			];
+			var duration = { duration: time_anim, easing: 'linear' };
+
+			var edit_link_wrap = getSeriesRowsEditLinkWrap(onscreen_rows[i]);
+			edit_link_wrap.style.display = "";
+			edit_link_wrap.animate(transform, duration);
+			var copy_title_wrap = getSeriesRowsCopyTitleWrap(onscreen_rows[i]);
+			copy_title_wrap.style.display = "";
+			copy_title_wrap.animate(transform, duration);
+			var tab_url_as_link_wrap = getSeriesRowsTabURLAsLinkWrap(onscreen_rows[i]);
+			tab_url_as_link_wrap.style.display = "";
+			tab_url_as_link_wrap.animate(transform, duration);
 		}
 	});
 }

--- a/src/js/pop_action.js
+++ b/src/js/pop_action.js
@@ -105,6 +105,8 @@ function toggleManageModeVisibility(toggle) {
 	toggleManageFieldVisibility(toggle);
 	toggleSeriesSelectVisibility(toggle);
 	toggleEditLinkVisibility(toggle);
+	toggleCopyTitleVisibility(toggle);
+	toggleTabURLAsLinkVisibility(toggle);
 }
 
 /**

--- a/src/js/pop_series_action.js
+++ b/src/js/pop_series_action.js
@@ -230,6 +230,28 @@ function toggleEditLinkVisibility(toggle) {
 }
 
 /**
+ * toggles visibility for all copy title buttons
+ * @param {boolean} toggle
+ */
+function toggleCopyTitleVisibility(toggle) {
+	var copy_wraps = document.body.getElementsByClassName("copyTitleWrap");
+	for (var i = 0; i < copy_wraps.length; i++) {
+		toggleElementVisibility(copy_wraps[i], toggle);
+	}
+}
+
+/**
+ * toggles visibility for all copy title buttons
+ * @param {boolean} toggle
+ */
+function toggleTabURLAsLinkVisibility(toggle) {
+	var copy_wraps = document.body.getElementsByClassName("tabURLAsLinkWrap");
+	for (var i = 0; i < copy_wraps.length; i++) {
+		toggleElementVisibility(copy_wraps[i], toggle);
+	}
+}
+
+/**
  * updates the user input volume and chapter on popup, locally and pushes change to MU
  * @param {Element} series_row
  * @param {string} vol_input

--- a/src/js/pop_series_builder.js
+++ b/src/js/pop_series_builder.js
@@ -116,6 +116,9 @@ function buildTitleBlock(data_list, data_series) {
 	if (len > 50) font_size = 10;
 	title_cont.style.fontSize = font_size + 'px';
 	var edit_link_wrap = buildEditLinkButton(data_series);
+	var copy_title_wrap = buildCopyTitleButton(data_series);
+	var tab_url_as_link_wrap = buildSetTabURLAsLinkButton(data_series);
+
 	if (!isEmpty(data_series.unread_releases)) {
 		if (data_series.unread_releases.length > 1 || data_series.latest_unread_release.marked_seen) {
 			var badge = buildBadge(data_series.unread_releases.length);
@@ -131,6 +134,8 @@ function buildTitleBlock(data_list, data_series) {
 	title_disp.appendChild(title_cont);
 	title_cont.appendChild(title_link);
 	title_block.appendChild(edit_link_wrap);
+	title_block.appendChild(copy_title_wrap);
+	title_block.appendChild(tab_url_as_link_wrap);
 
 	return title_block;
 }
@@ -163,6 +168,69 @@ function buildEditLinkButton(data_series) {
 	edit_link_wrap.appendChild(edit_link_button);
 
 	return edit_link_wrap;
+}
+
+/**
+ * builds DOM button for copying the title associated with selected series
+ * @param {Series} data_series
+ * @returns {Element}
+ */
+function buildCopyTitleButton(data_series) {
+	var copy_title_button = document.createElement("div");
+	copy_title_button.className = "copyTitleButton";
+	copy_title_button.onclick =  function(event) {
+		navigator.clipboard.writeText(data_series.title);
+	};
+	copy_title_button.title = "Copy Title";
+	var copy_title_icon = document.createElement("div");
+	copy_title_icon.className = "copyTitleIcon";
+	copy_title_icon.textContent = "C";
+	var copy_title_wrap = document.createElement("div");
+	copy_title_wrap.className = "copyTitleWrap";
+	if (!manageModeOn()) {
+		copy_title_wrap.style.display = "none";
+	}
+
+	if (exists(data_series.user_link)) {
+		copy_title_icon.style.opacity = 1;
+		copy_title_button.style.opacity = .9;
+	}
+
+	copy_title_button.appendChild(copy_title_icon);
+	copy_title_wrap.appendChild(copy_title_button);
+
+	return copy_title_wrap;
+}
+
+/**
+ * builds DOM button for setting the current tab's url as link associated with selected series
+ * @param {Series} data_series
+ * @returns {Element}
+ */
+function buildSetTabURLAsLinkButton(data_series) {
+	var tab_url_as_link_button = document.createElement("div");
+	tab_url_as_link_button.className = "tabURLAsLinkButton";
+	tab_url_as_link_button.onclick =  handleSetCurrentPageAsLink;
+	tab_url_as_link_button.title = "Set Tab URL As Link";
+	var tab_url_as_link_icon = document.createElement("div");
+	tab_url_as_link_icon.className = "tabURLAsLinkIcon";
+	tab_url_as_link_icon.textContent = "+";
+	var tab_url_as_link_wrap = document.createElement("div");
+	tab_url_as_link_wrap.className = "tabURLAsLinkWrap";
+	if (!manageModeOn()) {
+		tab_url_as_link_wrap.style.display = "none";
+	}
+
+	if (exists(data_series.user_link)) {
+		tab_url_as_link_icon.style.opacity = 1;
+		tab_url_as_link_button.style.opacity = .9;
+	}
+
+	tab_url_as_link_button.appendChild(tab_url_as_link_icon);
+	tab_url_as_link_wrap.appendChild(tab_url_as_link_button);
+
+	return tab_url_as_link_wrap;
+
 }
 
 /**

--- a/src/js/pop_series_handler.js
+++ b/src/js/pop_series_handler.js
@@ -195,6 +195,38 @@ function handleCompleteEditLink(event) {
 	input_link.parentElement.removeChild(input_link);
 }
 
+function handleSetCurrentPageAsLink(event) {
+	var input_link = event.target;
+	var link = input_link.value;
+	chrome.tabs.getSelected(null, function(tab) {
+        link = tab.url;
+
+		console.log("setting link as " + link);
+		var link_is_empty = (link === "");
+		var series_row = getInputLinksSeriesRow(input_link);
+		var series_id = getSeriesRowsId(series_row);
+		var title_link = getSeriesRowsTitleLink(series_row);
+		
+		var link_button = getSeriesRowsEditLinkButton(series_row);
+		var link_icon = getEditLinkButtonsLinkIcon(link_button);
+	
+		if (link_is_empty) {
+			var default_link = getDefaultLink(series_id);
+			userClearSeriesLink(series_id);
+			title_link.removeAttribute("user_link");
+			title_link.setAttribute("default_link", default_link);
+			link_button.style.removeProperty("opacity");
+			link_icon.style.removeProperty("opacity");
+		} else {
+			link = validateUrl(link);
+			userSetSeriesLink(series_id, link);
+			title_link.setAttribute("user_link", link);
+			link_button.style.opacity = .97;
+			link_icon.style.opacity = 1;
+		}
+	});
+}
+
 /**
  * creates the textbox to enter custom series link
  * @param {Event} event

--- a/src/js/pop_traverser.js
+++ b/src/js/pop_traverser.js
@@ -64,6 +64,53 @@ function getSeriesRowsEditLinkWrap(series_row) {
 }
 
 /**
+ * @param {Element} series_row
+ * @returns {Element}
+ */
+function getSeriesRowsCopyTitleButton(series_row) {
+	return series_row.querySelector('.copyTitleButton');
+}
+
+/**
+ * @param {Element} link_button
+ * @returns {Element}
+ */
+function getCopyTitleButtonsLinkIcon(link_button) {
+	return link_button.querySelector('.copyTitleIcon');
+}
+
+/**
+ * @param {Element} series_row
+ * @returns {Element}
+ */
+function getSeriesRowsCopyTitleWrap(series_row) {
+	return series_row.querySelector('.copyTitleWrap');
+}
+
+/**
+ * @param {Element} series_row
+ * @returns {Element}
+ */
+function getSeriesRowsTabURLAsLinkButton(series_row) {
+	return series_row.querySelector('.tabURLAsLinkButton');
+}
+
+/**
+ * @param {Element} link_button
+ * @returns {Element}
+ */
+function getTabURLAsLinkButtonsLinkIcon(link_button) {
+	return link_button.querySelector('.tabURLAsLinkIcon');
+}
+
+/**
+ * @param {Element} series_row
+ * @returns {Element}
+ */
+function getSeriesRowsTabURLAsLinkWrap(series_row) {
+	return series_row.querySelector('.tabURLAsLinkWrap');
+}
+/**
  * @param {Element} input_link
  * @returns {Element}
  */


### PR DESCRIPTION
- Added a copy title that copies the title of its related series. 
- Added a + button that sets the open and focused on tab's url as the link for the series. 
- Both attached the same way that edit Link is.
- Renamed animation handler for edit Link, and put the two buttons there so that it applies on both of them as well. 
- Both of them only appear on Manage Mode